### PR TITLE
[Add]SpringTestの実装

### DIFF
--- a/src/main/java/com/raisetech/work09/Name.java
+++ b/src/main/java/com/raisetech/work09/Name.java
@@ -3,6 +3,8 @@ package com.raisetech.work09;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
+import java.util.Objects;
+
 @RequiredArgsConstructor
 @Setter
 public class Name {
@@ -19,5 +21,17 @@ public class Name {
 
     public String getName() {
         return name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Name name1)) return false;
+        return id == name1.id && name.equals(name1.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name);
     }
 }

--- a/src/test/java/com/raisetech/work09/NameServiceImplTest.java
+++ b/src/test/java/com/raisetech/work09/NameServiceImplTest.java
@@ -1,0 +1,29 @@
+package com.raisetech.work09;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class NameServiceImplTest {
+    @InjectMocks
+    NameServiceImpl nameServiceImpl;
+    @Mock
+    NameMapper nameMapper;
+
+    @Test
+    public void 存在するユーザーIDを指定したときに正常にユーザーが返されること() throws Exception {
+        doReturn(Optional.of(new Name("koyama"))).when(nameMapper).findById(1);
+        //findById(1)実行時、必ずid:1, name:yoshihito koyama　を返す
+
+        Name actual = nameServiceImpl.findById(1);
+        assertThat(actual).isEqualTo(new Name("koyama"));
+    }
+}

--- a/src/test/java/com/raisetech/work09/NameServiceImplTest.java
+++ b/src/test/java/com/raisetech/work09/NameServiceImplTest.java
@@ -9,9 +9,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 class NameServiceImplTest {
@@ -30,20 +29,10 @@ class NameServiceImplTest {
     }
 
     @Test
-    public void 存在しないユーザーIDを指定したときに期待通り例外を返すこと() throws Exception {
-        doThrow(new ResourceNotFoundException("例外です")).when(nameMapper).findById(0);
-        Throwable throwable = catchThrowable(() -> nameServiceImpl.findById(0));
-        /*catchThrowableを使うことで、与えられたコードブロックを実行し、
-        その中でスローされた例外をキャッチして返す、若しくは例外がスローされなかったらnullを返す
-        */
-        assertThat(throwable).isInstanceOf(ResourceNotFoundException.class).hasMessage("例外です");
-        /*assertThatThrownByで試したが、アサーションエラーが発生した。
-        同メソッドが期待するような形式で例外をラップできていなかった可能性があり、
-        isInstanceOfメソッドを使用して、スローされた例外が期待通りの型であることを確認することになった。
-         */
-        assertThat(throwable.getCause()).isNull();
-        /*ResourceNotFoundExceptionは通常別の例外が原因となってスローされるケースがあるので
-        その原因となる別の例外が存在しないことを検証している。
-        その別の例外が存在する場合、getCause()はその例外を返すため、isNull()は失敗する*/
+    public void 存在しないユーザーIDを指定したときに期待通り例外を返すこと() {
+        doReturn(Optional.empty()).when(nameMapper).findById(0);
+        assertThatThrownBy(() -> nameServiceImpl.findById(0))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessage("resource not found with id: 0");
     }
 }

--- a/src/test/java/com/raisetech/work09/NameServiceImplTest.java
+++ b/src/test/java/com/raisetech/work09/NameServiceImplTest.java
@@ -9,7 +9,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
 
 @ExtendWith(MockitoExtension.class)
 class NameServiceImplTest {
@@ -25,5 +27,23 @@ class NameServiceImplTest {
 
         Name actual = nameServiceImpl.findById(1);
         assertThat(actual).isEqualTo(new Name("koyama"));
+    }
+
+    @Test
+    public void 存在しないユーザーIDを指定したときに期待通り例外を返すこと() throws Exception {
+        doThrow(new ResourceNotFoundException("例外です")).when(nameMapper).findById(0);
+        Throwable throwable = catchThrowable(() -> nameServiceImpl.findById(0));
+        /*catchThrowableを使うことで、与えられたコードブロックを実行し、
+        その中でスローされた例外をキャッチして返す、若しくは例外がスローされなかったらnullを返す
+        */
+        assertThat(throwable).isInstanceOf(ResourceNotFoundException.class).hasMessage("例外です");
+        /*assertThatThrownByで試したが、アサーションエラーが発生した。
+        同メソッドが期待するような形式で例外をラップできていなかった可能性があり、
+        isInstanceOfメソッドを使用して、スローされた例外が期待通りの型であることを確認することになった。
+         */
+        assertThat(throwable.getCause()).isNull();
+        /*ResourceNotFoundExceptionは通常別の例外が原因となってスローされるケースがあるので
+        その原因となる別の例外が存在しないことを検証している。
+        その別の例外が存在する場合、getCause()はその例外を返すため、isNull()は失敗する*/
     }
 }


### PR DESCRIPTION
# 概要
8ce83b9f88756132af40dda809125136523bcdf7
* 第13回課題のSpring Testの実装
* Test配下にNameServiceImplTestを追加
* 「存在するユーザーIDを指定したときに正常にユーザーが返されること」テストを実装
* Nameクラスにequals/hashcodeメソッドを実装

# 実行結果
![image](https://user-images.githubusercontent.com/117643710/221327995-c5176e8f-a506-44ae-ad01-202c1135723b.png)

# equals/hashcodeメソッド
* [参考サイト](https://qiita.com/yachinco/items/b1a3602d6aa261f5f7c4)
* 追加したequals/hashcodeメソッドはそのsuperクラスをoverrideして今回のテストコードにおいて都合のよい形式にしている（nameが他のnameと同値だったらtrueを返すように上書き）
* 同メソッドを追加しないで実行した場合superクラスが呼ばれる
  * superクラスのequalsメソッドは「オブジェクトの同一性」に基づいて「オブジェクトの同値性」を判定する
  * Nameクラスのインスタンスはidでもnameでもなく、インスタンスがまったく同じものである場合にsuperのequalsメソッドがtrueを返すということになる
  * これらの結果、テストがうまくいかない
![image](https://user-images.githubusercontent.com/117643710/221328033-83116b2b-7b14-4f8e-8ce6-79dd1ea770fb.png)

* hashcodeが必要であることのイメージはArrayListとHashSetの違いから考えると理解しやすい
  * ArrayList：一列のリストに要素が順番に追加されていき、検索時はリストの先頭から順番に探索
  * HashSet：hashcode1, hascode2...の各部屋に追加されていき、検索時はhashcodeが等しい分類に対してのみ探索
* hashcodeとequalsは両方ovverideで実装が必要
* hashcodeが正しく実装されていないと、同値のオブジェクトであるにもかかわらず異なる部屋に対象となるオブジェクトを探しにいってしまい、対象となるオブジェクトが見つからないという事態が発生する可能性がある
  * （オプション）hashCodeが0を返すように実装しても機能はする。が、実質部屋番号0の部屋にすべてのオブジェクトが格納されることになり、アルゴリズムとしてはArrayListに要素を追加することと同じとなり、HashListのハッシュアルゴリズムの利点（hashcodeが等しい分類に対してのみ探索する効率の良いやり方）が得られない
* オブジェクトの同一性
![image](https://user-images.githubusercontent.com/117643710/221327703-731109b5-2315-4da4-b3b9-cd813cbeee18.png)
* オブジェクトの同値性
![image](https://user-images.githubusercontent.com/117643710/221327725-bb7a8ad9-88b7-4fb7-9dcf-fd016dd20e2f.png)
