### PR TITLE
[Add]MyBatisTest：すべてのユーザーが取得できることテストを実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.1'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
     implementation 'org.projectlombok:lombok:1.18.22'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/raisetech/work09/Name.java
+++ b/src/main/java/com/raisetech/work09/Name.java
@@ -15,6 +15,11 @@ public class Name {
         this.name = name;
     }
 
+    public Name(int id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public int getId() {
         return id;
     }

--- a/src/test/java/com/raisetech/work09/NameMapperTest.java
+++ b/src/test/java/com/raisetech/work09/NameMapperTest.java
@@ -1,0 +1,40 @@
+package com.raisetech.work09;
+
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@MybatisTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+//Replace.NONE：テスト用データベースの設定を手動で行う
+class NameMapperTest {
+
+    @Autowired
+    NameMapper nameMapper;
+
+    @Test
+    @Sql(
+            scripts = {"classpath:/delete-names.sql", "classpath:/insert-names.sql"},
+            executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD
+    )
+    @Transactional
+    void すべてのユーザーが取得できること() {
+        List<Name> names = nameMapper.findAll();
+        assertThat(names)
+                .hasSize(3)
+                .contains(
+                        new Name(1, "Shimizu"),
+                        new Name(2, "Koyama"),
+                        new Name(3, "Tanaka")
+                );
+    }
+
+}

--- a/src/test/resources/delete-names.sql
+++ b/src/test/resources/delete-names.sql
@@ -1,0 +1,1 @@
+DELETE FROM names;

--- a/src/test/resources/insert-names.sql
+++ b/src/test/resources/insert-names.sql
@@ -1,0 +1,3 @@
+INSERT INTO names (id, name) VALUES (1,"Shimizu");
+INSERT INTO names (id, name) VALUES (2,"Koyama");
+INSERT INTO names (id, name) VALUES (3,"Tanaka");


### PR DESCRIPTION
# 概要
* 第13回課題のうち、DBテストをMyBatisTestを使用して実装した
* NameMapperTestクラスにてすべてのユーザーが取得できることテストを実装
* UserMapperをDI機能を使ってフィールドに定義
* テストメソッドには@Sqlと@Transactionalを用いてDBの初期化及びテスト実施後のロールバック？を行わせる

# 試したこと
## hasSize()について
* 最初エディタ上で有効にならなかった
* assertThatメソッドはJUnit4のorg.junit.Assertクラスに含まれる静的メソッド
* JUnit5からはこのassertThatが提供されていないためorg.assertj.core.api.AssertionsクラスのassertThatを使用する必要がある

## DB登録内容について
* NameクラスにString nameを引数にしたコンストラクタしかなかったので、sqlとテストコードにname情報しか書かなかったところ下記のエラーが出た
```
Expecting ArrayList:
  [com.raisetech.work09.Name@de18065a,
    com.raisetech.work09.Name@8650282e,
    com.raisetech.work09.Name@94e17c83]
to contain:
  [com.raisetech.work09.Name@de18042c,
    com.raisetech.work09.Name@865025e1,
    com.raisetech.work09.Name@94e17a17]
but could not find the following element(s):
  [com.raisetech.work09.Name@de18042c,
    com.raisetech.work09.Name@865025e1,
    com.raisetech.work09.Name@94e17a17]
```
* NameにString name, int idを引数にしたコンストラクタを追加して対応したらテスト通った。

# 実行結果
![image](https://user-images.githubusercontent.com/117643710/222146232-23f7c176-712a-4df8-8332-af2d808f9d9d.png)
