### PR TITLE
[Add]ユーザーが全件取得できることテストの実装

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ dependencies {
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.0'
     implementation 'org.springframework.boot:spring-boot-starter-validation:3.0.1'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.1'
+    implementation 'com.github.database-rider:rider-spring:1.36.0'
     annotationProcessor 'org.projectlombok:lombok:1.18.22'
     implementation 'org.projectlombok:lombok:1.18.22'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -34,20 +34,23 @@ public class UserRestApiIntegrationTest {
                 .andExpect(MockMvcResultMatchers.status().isOk())
                 .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
 
-        JSONAssert.assertEquals("[" +
-                " {" +
-                " \"id\": 1," +
-                " \"name\": \"清水\"" +
-                " }," +
-                " {" +
-                " \"id\": 2," +
-                " \"name\": \"小山\"" +
-                " }," +
-                " {" +
-                " \"id\": 3," +
-                " \"name\": \"田中\"" +
-                " }" +
-                "]", response, JSONCompareMode.STRICT);
+        JSONAssert.assertEquals("""
+                         [
+                            {
+                               "id":1,
+                               "name":"清水"
+                            },
+                            {
+                               "id":2,
+                               "name":"小山"
+                            },
+                            {
+                               "id":3,
+                               "name":"田中"
+                            }
+                         ]           
+                        """
+                , response, JSONCompareMode.STRICT);
 
     }
 }

--- a/src/test/java/integrationtest/UserRestApiIntegrationTest.java
+++ b/src/test/java/integrationtest/UserRestApiIntegrationTest.java
@@ -1,0 +1,53 @@
+package integrationtest;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.spring.api.DBRider;
+import com.raisetech.work09.Work09Application;
+import org.junit.jupiter.api.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+
+@SpringBootTest(classes = Work09Application.class)
+@AutoConfigureMockMvc
+@DBRider
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public class UserRestApiIntegrationTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DataSet(value = "users.yml")
+    @Transactional
+    void ユーザーが全件取得できること() throws Exception {
+        String response = mockMvc.perform(MockMvcRequestBuilders.get("/names"))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andReturn().getResponse().getContentAsString(StandardCharsets.UTF_8);
+
+        JSONAssert.assertEquals("[" +
+                " {" +
+                " \"id\": 1," +
+                " \"name\": \"清水\"" +
+                " }," +
+                " {" +
+                " \"id\": 2," +
+                " \"name\": \"小山\"" +
+                " }," +
+                " {" +
+                " \"id\": 3," +
+                " \"name\": \"田中\"" +
+                " }" +
+                "]", response, JSONCompareMode.STRICT);
+
+    }
+}

--- a/src/test/resources/dbunit.yml
+++ b/src/test/resources/dbunit.yml
@@ -1,0 +1,9 @@
+cacheConnection: false
+cacheTableNames: false
+properties:
+  schema: name_list
+caseInsensitiveStrategy: LOWERCASE
+connectionConfig:
+  url: "jdbc:mysql://localhost:3308/name_list"
+  user: "user"
+  password: "password"

--- a/src/test/resources/users.yml
+++ b/src/test/resources/users.yml
@@ -1,0 +1,8 @@
+names:
+  - id: 1
+    name: "清水"
+  - id: 2
+    name: "小山"
+  - id: 3
+    name: "田中"
+


### PR DESCRIPTION
# 概要

15e406e8e458ef9767ce51d36fda2e7987859b00

* 第13回課題のうち、結合テストの「ユーザーが全件取得できること」テストを実装
* SpringBootTest、DBRider、MockMvcなどを使用して実装
* MockMvcでusers.ymlを基にしたDBを用意し、JSONAssertでテーブルの内容が一致することを確認

# 実行結果
![image](https://user-images.githubusercontent.com/117643710/224999238-cd8341c8-bf31-42f7-8fcf-e33f406d074b.png)
